### PR TITLE
StreamProxy fix for KitKat

### DIFF
--- a/app/src/fm/last/android/player/StreamProxy.java
+++ b/app/src/fm/last/android/player/StreamProxy.java
@@ -157,7 +157,7 @@ public class StreamProxy implements Runnable {
     	  if(line != null && line.toLowerCase().startsWith("user-agent: ")) {
     		  ua = line.substring(12);
     	  }
-      } while(line != null && reader.ready());
+      } while("".equals(line) && reader.ready());
     } catch (IOException e) {
       Log.e(LOG_TAG, "Error parsing request", e);
       return request;


### PR DESCRIPTION
Use final blank line to detect end of GET request as BufferedReader::ready() seems broken on KitKat
