### PR TITLE
StreamProxy fix for KitKat

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="fm.last.android" android:versionCode="62" android:versionName="1.9.9.1">
+	package="fm.last.android" android:versionCode="63" android:versionName="1.9.9.2">
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/fm/last/android/player/StreamProxy.java
+++ b/app/src/fm/last/android/player/StreamProxy.java
@@ -157,7 +157,7 @@ public class StreamProxy implements Runnable {
     	  if(line != null && line.toLowerCase().startsWith("user-agent: ")) {
     		  ua = line.substring(12);
     	  }
-      } while(!"".equals(line) && reader.ready());
+      } while(line != null && !"".equals(line) && reader.ready());
     } catch (IOException e) {
       Log.e(LOG_TAG, "Error parsing request", e);
       return request;

--- a/app/src/fm/last/android/player/StreamProxy.java
+++ b/app/src/fm/last/android/player/StreamProxy.java
@@ -157,7 +157,7 @@ public class StreamProxy implements Runnable {
     	  if(line != null && line.toLowerCase().startsWith("user-agent: ")) {
     		  ua = line.substring(12);
     	  }
-      } while(line != null && reader.ready());
+      } while("".equals(line) && reader.ready());
     } catch (IOException e) {
       Log.e(LOG_TAG, "Error parsing request", e);
       return request;

--- a/app/src/fm/last/android/player/StreamProxy.java
+++ b/app/src/fm/last/android/player/StreamProxy.java
@@ -157,7 +157,7 @@ public class StreamProxy implements Runnable {
     	  if(line != null && line.toLowerCase().startsWith("user-agent: ")) {
     		  ua = line.substring(12);
     	  }
-      } while("".equals(line) && reader.ready());
+      } while(!"".equals(line) && reader.ready());
     } catch (IOException e) {
       Log.e(LOG_TAG, "Error parsing request", e);
       return request;


### PR DESCRIPTION
Use final blank line to detect end of GET request as BufferedReader::ready() seems broken on KitKat.
