### PR TITLE
Remove try/catch block by eliminating possible NPE

### DIFF
--- a/app/src/fm/last/android/activity/Profile_ChartsTab.java
+++ b/app/src/fm/last/android/activity/Profile_ChartsTab.java
@@ -373,12 +373,8 @@ public class Profile_ChartsTab extends ListActivity {
 		getListView().setEnabled(true);
 
 		for (ListView list : mProfileLists) {
-			try {
-				((ListAdapter) list.getAdapter()).disableLoadBar();
-			} catch (Exception e) {
-				// FIXME: this is ugly, but sometimes adapters aren't the
-				// shape we expect.
-			}
+                        if (list.getAdapter() != null && list.getAdapter().getClass().equals(ListAdapter.class))
+                                ((ListAdapter) list.getAdapter()).disableLoadBar();
 		}
 
 		super.onResume();


### PR DESCRIPTION
Getting rid of a try/catch block that presumably exists to catch a NPE on the return value of `list.getAdapter`. This pull request allows the removal of this block by checking that the return value of `list.getAdapter` is non-null and has the expected `ListAdapter` type. This check on the return value of `list.getAdapter` is used in several other places in the code.
